### PR TITLE
Building on Mac OS X

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -29,10 +29,10 @@ m: m.fl Bargraph.cxx Bargraph.h Codebox.cxx Codebox.h Cw.cxx Cw.h \
 	g++ -c -Os `fltk-config --cxxflags` Bargraph.cxx	
 	g++ -c -Os `fltk-config --cxxflags` Codebox.cxx
 	g++ -c -Os `fltk-config --cxxflags` Knob.cxx
-	g++ -c -Os `sdl-config    --cflags` Cw.cxx
-	g++ -static -om m.o Bargraph.o Codebox.o Cw.o Knob.o \
-	  `sdl-config --static-libs` \
-	  `fltk-config --ldstaticflags` -ldl
+	g++ -c -Os `sdl-config --cflags` Cw.cxx
+	g++ -o m m.o Bargraph.o Codebox.o Cw.o Knob.o \
+	  `sdl-config --libs` \
+	  `fltk-config --ldflags` -ldl
 	strip m
 	rm *.o m.cxx m.h
 


### PR DESCRIPTION
Hello Ward,

I initially tried running the prebuilt version on c2.com/morse but, as the page mentions, it crashes.

I then downloaded the source and patched it slightly to compile on OS X Snow Leopard. Unfortunately, you can't easily compile static apps. Anyway, I then found a number of forks on github including https://github.com/drewish/morse which builds a nice OS X app bundle. Unfortunately Andrew kept the original static flags which cause the app to crash. I once again patched the makefile. On my 10.6.6 OS X machine it works wonderfully. 

Thanks for a fantastic app!
